### PR TITLE
feat: add release.sh entry point and improve create-gh-releases.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
 .DS_Store
 env
-
+.claude
+venv
+.venv

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Generates a Markdown or CSV table of PRs merged between two tags for a given rep
 
 ### Prerequisites
 
-Complete the [Setup](#setup) steps above. Also requires `SOURCES_BASE_DIR` to be set in `env` (path where the target repo is `git clone`d).
+```
+source ./env   # sets KOBO_BASE_DIR
+```
 
 ### Usage:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-# release-notes-writer
-Compile release notes as a Markdown table from PR titles and descriptions
-
-This is pre-alpha software: in effect, it's just a utility script to decrease
-slightly the amount of manual work needed to publish KoboToolbox release
-notes at https://community.kobotoolbox.org/tags/c/announcements/7/release-notes
-
----
-
 > **Deprecated:** `release-notes.py` is no longer maintained. Its documentation is kept below for reference.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
-> **Deprecated:** `release-notes.py` is no longer maintained. Its documentation is kept below for reference.
-
-<details>
-<summary>release-notes.py (deprecated)</summary>
-
-Generates a Markdown or CSV table of PRs merged between two tags for a given repo.
-
-### Prerequisites
-
-Complete the [Setup](#setup) steps above. Also requires `SOURCES_BASE_DIR` to be set in `env` (path where the target repo is `git clone`d).
-
-### Usage:
-
-```
-python3 release-notes.py [--markdown] <repo> <previous-tag> <new-tag>
-```
-
-**Examples:**
-
-```
-python3 release-notes.py kpi 2.025.10 2.026.07h
-python3 release-notes.py --markdown kpi 2.025.10 2.026.07h
-```
-
-- Without `--markdown`: outputs CSV to stdout
-- With `--markdown`: outputs a Markdown table to stdout
-- Warnings about missing PRs are printed to stderr
-
-</details>
-
 # Setup
 
 ### 1. Create a virtual environment and install dependencies
@@ -115,3 +85,35 @@ python3 create-gh-releases.py <tag>
 ```
 python3 create-gh-releases.py 2.026.07h
 ```
+
+---
+
+> **Deprecated:** `release-notes.py` is no longer maintained. Its documentation is kept below for reference.
+
+<details>
+<summary>release-notes.py (deprecated)</summary>
+
+Generates a Markdown or CSV table of PRs merged between two tags for a given repo.
+
+### Prerequisites
+
+Complete the [Setup](#setup) steps above. Also requires `SOURCES_BASE_DIR` to be set in `env` (path where the target repo is `git clone`d).
+
+### Usage:
+
+```
+python3 release-notes.py [--markdown] <repo> <previous-tag> <new-tag>
+```
+
+**Examples:**
+
+```
+python3 release-notes.py kpi 2.025.10 2.026.07h
+python3 release-notes.py --markdown kpi 2.025.10 2.026.07h
+```
+
+- Without `--markdown`: outputs CSV to stdout
+- With `--markdown`: outputs a Markdown table to stdout
+- Warnings about missing PRs are printed to stderr
+
+</details>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,38 @@ This is pre-alpha software: in effect, it's just a utility script to decrease
 slightly the amount of manual work needed to publish KoboToolbox release
 notes at https://community.kobotoolbox.org/tags/c/announcements/7/release-notes
 
+---
+
+> **Deprecated:** `release-notes.py` is no longer maintained. Its documentation is kept below for reference.
+
+<details>
+<summary>release-notes.py (deprecated)</summary>
+
+Generates a Markdown or CSV table of PRs merged between two tags for a given repo.
+
+### Prerequisites
+
+Complete the [Setup](#setup) steps above. Also requires `SOURCES_BASE_DIR` to be set in `env` (path where the target repo is `git clone`d).
+
+### Usage:
+
+```
+python3 release-notes.py [--markdown] <repo> <previous-tag> <new-tag>
+```
+
+**Examples:**
+
+```
+python3 release-notes.py kpi 2.025.10 2.026.07h
+python3 release-notes.py --markdown kpi 2.025.10 2.026.07h
+```
+
+- Without `--markdown`: outputs CSV to stdout
+- With `--markdown`: outputs a Markdown table to stdout
+- Warnings about missing PRs are printed to stderr
+
+</details>
+
 # Setup
 
 ### 1. Create a virtual environment and install dependencies

--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@ This is pre-alpha software: in effect, it's just a utility script to decrease
 slightly the amount of manual work needed to publish KoboToolbox release
 notes at https://community.kobotoolbox.org/tags/c/announcements/7/release-notes
 
-# release
+# Setup
 
-One-shot script that runs `create-kobo-release.sh` then `create-gh-releases.py`.
+### 1. Create a virtual environment and install dependencies
 
-### Prerequisites
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 2. Configure environment variables
 
 Copy `env.sample` to `env`, fill in your values, then source it:
 
@@ -18,6 +24,16 @@ cp env.sample env
 # edit env with your values
 source ./env
 ```
+
+---
+
+# release
+
+One-shot script that runs `create-kobo-release.sh` then `create-gh-releases.py`.
+
+### Prerequisites
+
+Complete the [Setup](#setup) steps above.
 
 `release.sh` will exit with a clear error if `KOBO_BASE_DIR` or `GITHUB_API_TOKEN` are not set.
 
@@ -41,9 +57,7 @@ Tags and updates `kobo-docker` and `kobo-install` for a new release.
 
 ### Prerequisites
 
-```
-source ./env   # sets KOBO_BASE_DIR
-```
+Complete the [Setup](#setup) steps above.
 
 ### Usage:
 
@@ -63,9 +77,7 @@ Creates GitHub releases for the following KoboToolbox repositories:
 
 ### Prerequisites
 
-```
-source ./env   # sets GITHUB_API_TOKEN
-```
+Complete the [Setup](#setup) steps above.
 
 ### Usage:
 

--- a/README.md
+++ b/README.md
@@ -5,24 +5,76 @@ This is pre-alpha software: in effect, it's just a utility script to decrease
 slightly the amount of manual work needed to publish KoboToolbox release
 notes at https://community.kobotoolbox.org/tags/c/announcements/7/release-notes
 
-# create-gh-releases
+# release
 
-Create a GitHub release for the following KoboToolbox repositories:
+One-shot script that runs `create-kobo-release.sh` then `create-gh-releases.py`.
 
-- [kobo-docker](https://github.com/kobotoolbox/kobo-docker/releases)
-- [kobo-install](https://github.com/kobotoolbox/kobo-install/releases)
-- [KPI](https://github.com/kobotoolbox/kpi/releases)
+### Prerequisites
 
-### Usage: 
+Copy `env.sample` to `env`, fill in your values, then source it:
 
 ```
-➜  release-notes-writer git:(main) ✗ source ./env
-➜  release-notes-writer git:(main) ✗ python3 create-gh-releases.py <tag> <link.to.release.notes>
+cp env.sample env
+# edit env with your values
+source ./env
+```
+
+`release.sh` will exit with a clear error if `KOBO_BASE_DIR` or `GITHUB_API_TOKEN` are not set.
+
+### Usage:
+
+```
+./release.sh <tag>
 ```
 
 **Example:**
 
 ```
-python3 create-gh-releases.py 2.099.01 https://community.kobotoolbox.org/t/release-2-099-01/111111/1
+./release.sh 2.026.07h
 ```
 
+---
+
+# create-kobo-release
+
+Tags and updates `kobo-docker` and `kobo-install` for a new release.
+
+### Prerequisites
+
+```
+source ./env   # sets KOBO_BASE_DIR
+```
+
+### Usage:
+
+```
+./create-kobo-release.sh <tag>
+```
+
+---
+
+# create-gh-releases
+
+Creates GitHub releases for the following KoboToolbox repositories:
+
+- [kobo-docker](https://github.com/kobotoolbox/kobo-docker/releases) — body links to the KPI release
+- [kobo-install](https://github.com/kobotoolbox/kobo-install/releases) — body links to the KPI release
+- [KPI](https://github.com/kobotoolbox/kpi/releases) — body uses `CHANGELOG.md` from the `changelog/<tag>` branch, falls back to auto-generated release notes
+
+### Prerequisites
+
+```
+source ./env   # sets GITHUB_API_TOKEN
+```
+
+### Usage:
+
+```
+python3 create-gh-releases.py <tag>
+```
+
+**Example:**
+
+```
+python3 create-gh-releases.py 2.026.07h
+```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Tags and updates `kobo-docker` and `kobo-install` for a new release.
 
 ### Prerequisites
 
-Complete the [Setup](#setup) steps above.
+```
+source ./env   # sets KOBO_BASE_DIR
+```
 
 ### Usage:
 

--- a/create-gh-releases.py
+++ b/create-gh-releases.py
@@ -2,12 +2,38 @@
 import os
 import sys
 
-import requests
+try:
+    import requests
+except ImportError:
+    print('ERROR: `requests` is not installed. Run: pip install requests')
+    sys.exit(1)
 
-# Usage: ./create-gh-releases.py [tag]
+# Usage: ./create-gh-releases.py <tag>
 
 # Generate a token at https://github.com/settings/tokens
 GITHUB_API_TOKEN = os.environ['GITHUB_API_TOKEN']
+
+CHANGELOG_RAW_URL = (
+    'https://raw.githubusercontent.com/kobotoolbox/kpi/changelog/{tag}/CHANGELOG.md'
+)
+
+
+REQUEST_TIMEOUT = 15  # seconds
+
+
+def fetch_kpi_changelog(tag: str) -> str | None:
+    """Fetch CHANGELOG.md from the changelog/<tag> branch. Returns None on failure."""
+    url = CHANGELOG_RAW_URL.format(tag=tag)
+    try:
+        resp = requests.get(url, timeout=REQUEST_TIMEOUT)
+    except requests.exceptions.RequestException as exc:
+        print(f'WARNING: Could not fetch CHANGELOG.md ({exc})')
+        return None
+
+    if resp.status_code == 200:
+        return resp.text
+
+    return None
 
 
 def run(tag: str):
@@ -27,43 +53,75 @@ def run(tag: str):
         'X-GitHub-Api-Version': '2022-11-28'
     }
 
-    # Generate the release notes link automatically
-    release_notes_link = f'https://github.com/kobotoolbox/kpi/releases/tag/{tag}'
+    kpi_release_link = f'https://github.com/kobotoolbox/kpi/releases/tag/{tag}'
+    errors = []
 
     for repo in repos:
-        # For KPI repo: auto-generate changelog, no custom body
         if repo == 'kpi':
-            body = ''
-            generate_releases_notes = True
+            changelog = fetch_kpi_changelog(tag)
+            if changelog:
+                print(f'Using CHANGELOG.md from changelog/{tag} branch for kpi')
+                payload = {
+                    'tag_name': tag,
+                    'name': tag,
+                    'body': changelog,
+                    'draft': False,
+                    'prerelease': False,
+                    'generate_release_notes': False,
+                }
+            else:
+                print(
+                    f'CHANGELOG.md not found at changelog/{tag}, '
+                    'falling back to auto-generated release notes for kpi'
+                )
+                payload = {
+                    'tag_name': tag,
+                    'name': tag,
+                    'body': '',
+                    'draft': False,
+                    'prerelease': False,
+                    'generate_release_notes': True,
+                }
         else:
-            body = f'For more information, please see {release_notes_link}',
-            generate_releases_notes = False
+            payload = {
+                'tag_name': tag,
+                'name': tag,
+                'body': f'For more information, please see {kpi_release_link}',
+                'draft': False,
+                'prerelease': False,
+                'generate_release_notes': False,
+            }
 
-        payload = {
-            'tag_name': tag,
-            'name': tag,
-            'body': '',  # Empty body
-            'draft': False,
-            'prerelease': False,
-            'generate_release_notes': True  # Auto-generate for KPI
-        }
+        try:
+            resp = requests.post(
+                create_release_endpoint.format(repo=repo),
+                json=payload,
+                headers=headers,
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.exceptions.RequestException as exc:
+            msg = f'ERROR creating release for {repo}: {exc}'
+            print(msg)
+            errors.append(msg)
+            continue
 
-        resp = requests.post(
-            create_release_endpoint.format(repo=repo),
-            json=payload,
-            headers=headers,
-        )
         if resp.status_code != 201:
-            print(resp.text)
-        else:
-            print(f'GH release for {repo} is created')
+            msg = f'ERROR creating release for {repo} (HTTP {resp.status_code}): {resp.text}'
+            print(msg)
+            errors.append(msg)
+            continue
+
+        print(f'GH release for {repo} created successfully')
+
+    if errors:
+        sys.exit(1)
 
 
 if __name__ == '__main__':
     try:
         tag_ = sys.argv[1]
     except IndexError:
-        print('Usage: ./create-gh-releases.py [tag]')
+        print('Usage: ./create-gh-releases.py <tag>')
         sys.exit(1)
 
     try:

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,3 @@
+export GITHUB_API_TOKEN=ghp_your_token_here
+export KOBO_BASE_DIR=/path/to/kobo
+export SOURCES_BASE_DIR=/path/to/sources

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Validate env vars --------------------------------------------------------
+missing=()
+[[ -z "${KOBO_BASE_DIR:-}" ]] && missing+=('KOBO_BASE_DIR')
+[[ -z "${GITHUB_API_TOKEN:-}" ]] && missing+=('GITHUB_API_TOKEN')
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: The following environment variables are not set:"
+  for var in "${missing[@]}"; do
+    echo "  - ${var}"
+  done
+  echo ""
+  echo "Run 'source ${SCRIPT_DIR}/env' first (copy env.sample if you don't have one)."
+  exit 1
+fi
+
+# --- Validate argument --------------------------------------------------------
+VERSION="${1:-}"
+
+if [[ -z "${VERSION}" ]]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 2.026.07h"
+  exit 1
+fi
+
+# --- Run steps ----------------------------------------------------------------
+echo "==> Step 1: Tagging and updating kobo-docker & kobo-install"
+bash "${SCRIPT_DIR}/create-kobo-release.sh" "${VERSION}"
+
+echo ""
+echo "==> Step 2: Creating GitHub releases"
+python3 "${SCRIPT_DIR}/create-gh-releases.py" "${VERSION}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2026.2.25
+charset-normalizer==3.4.7
+idna==3.11
+requests==2.33.1
+urllib3==2.6.3


### PR DESCRIPTION
## Summary
Running a KoboToolbox release required calling two separate scripts manually with the same arguments — this adds a single entry point that handles both steps and fails early with clear messages if the environment is not set up.

## Notes
- `release.sh` calls `create-kobo-release.sh` then `create-gh-releases.py`, both with the same `<tag>` argument. It checks `KOBO_BASE_DIR` and `GITHUB_API_TOKEN` upfront and exits with a list of missing vars + `source ./env` hint if either is absent.
- `env.sample` added as a template (the real `env` is already gitignored).
- `create-gh-releases.py` payload bug fixed: `body` and `generate_release_notes` were computed but never wired into the payload dict — always sending `body=''` and `generate_release_notes=True` for all repos.
- KPI release: now fetches `CHANGELOG.md` from `https://raw.githubusercontent.com/kobotoolbox/kpi/changelog/<tag>/CHANGELOG.md`; falls back to GitHub auto-generate if the branch/file doesn't exist (non-200).
- kobo-docker / kobo-install releases: body is now `For more information, please see https://github.com/kobotoolbox/kpi/releases/tag/<tag>`.
- All `requests` calls now have a 15 s timeout and are wrapped in `except RequestException`; errors are accumulated and the script exits with code 1 after processing all repos if any failed.
- `ImportError` guard added on `import requests` with `pip install requests` hint.